### PR TITLE
Fix protobuf version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-protobuf = "~1.4.3"
+protobuf = "~1.5"
 
 [build-dependencies]
-protoc-rust = "~1.4"
+protoc-rust = "~1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-protobuf = "1.4.3"
+protobuf = "~1.4.3"
 
 [build-dependencies]
-protoc-rust = "1.4"
+protoc-rust = "~1.4"


### PR DESCRIPTION
🐛 bug fix

A freshly cloned dat-network-protocol repo does not compile, because the latest protobuf lib (1.6) is incompatible with version 1.4. Restricting the version to 1.4.x solves the problem. See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

This PR also upgrades the protobuf lib to the latest compatible version which is 1.5

## Checklist
- [x] tests pass

## Semver Changes
Patch level
